### PR TITLE
Gui/Fixed command networkTab and fixed Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 ZAPPY_IA_DIR = ia
 ZAPPY_SERVER_DIR = server
-ZAPPY_CLIENT_DIR = client
+ZAPPY_CLIENT_DIR = gui
 
 ZAPPY_IA = zappy_ai
 ZAPPY_SERVER = zappy_server
+
+ZAPPY_CLIENT_BUILD_DIR = $(ZAPPY_CLIENT_DIR)/build
 ZAPPY_CLIENT = zappy_gui
 
 all: $(ZAPPY_IA) $(ZAPPY_SERVER) $(ZAPPY_CLIENT)
@@ -19,14 +21,16 @@ $(ZAPPY_SERVER):
 	@cp $(ZAPPY_SERVER_DIR)/$(ZAPPY_SERVER) .
 
 $(ZAPPY_CLIENT):
-	@echo "Compiling $(ZAPPY_CLIENT)..."
-	@make -C $(ZAPPY_CLIENT_DIR)
-	@cp $(ZAPPY_CLIENT_DIR)/$(ZAPPY_CLIENT) .
+	@echo "Compiling $(ZAPPY_CLIENT) with CMake..."
+	@if [ ! -d $(ZAPPY_CLIENT_BUILD_DIR) ]; then mkdir -p $(ZAPPY_CLIENT_BUILD_DIR); fi
+	@cd $(ZAPPY_CLIENT_BUILD_DIR) && cmake ..
+	@cd $(ZAPPY_CLIENT_BUILD_DIR) && make
+	@cp $(ZAPPY_CLIENT_DIR)/$(ZAPPY_CLIENT) ./
 
 clean:
 	@make -C $(ZAPPY_SERVER_DIR) clean
 	@make -C $(ZAPPY_IA_DIR) clean
-	@make -C $(ZAPPY_CLIENT_DIR) clean
+	@rm -rf $(ZAPPY_CLIENT_BUILD_DIR)
 	@find . -name "*~" -delete
 	@find . -name "*.pyc" -delete
 	@rm -f *.gcno
@@ -35,7 +39,6 @@ clean:
 fclean: clean
 	@make -C $(ZAPPY_SERVER_DIR) fclean
 	@make -C $(ZAPPY_IA_DIR) fclean
-	@make -C $(ZAPPY_CLIENT_DIR) fclean
 	@rm -f $(ZAPPY_IA)
 	@rm -f $(ZAPPY_SERVER)
 	@rm -f $(ZAPPY_CLIENT)

--- a/gui/src/gameEngine/GameEngine.cpp
+++ b/gui/src/gameEngine/GameEngine.cpp
@@ -35,7 +35,7 @@ float gui::GameEngine::getWorldScale() const {
 }
 
 void gui::GameEngine::setWorldScale(float value) {
-  worldScale = std::clamp(value, MIN_SCALE, MAX_SCALE);
+  worldScale = Clamp(value, MIN_SCALE, MAX_SCALE);
 }
 
 void gui::GameEngine::initialize() {
@@ -139,7 +139,13 @@ void gui::GameEngine::processNetworkMessages() {
     {"enw", [this](const std::string &msg) { _commandHandler.handleEnw(msg); }},
     {"ebo", [this](const std::string &msg) { _commandHandler.handleEbo(msg); }},
     {"edi", [this](const std::string &msg) { _commandHandler.handleEdi(msg); }},
-    {"pdi", [this](const std::string &msg) { _commandHandler.handlePdi(msg); }}
+    {"pdi", [this](const std::string &msg) { _commandHandler.handlePdi(msg); }},
+    {"pic", [this](const std::string &msg) { _commandHandler.handlePic(msg); }},
+    {"pie", [this](const std::string &msg) { _commandHandler.handlePie(msg); }},
+    {"pfk", [this](const std::string &msg) { _commandHandler.handlePfk(msg); }},
+    {"pdr", [this](const std::string &msg) { _commandHandler.handlePdr(msg); }},
+    {"pgt", [this](const std::string &msg) { _commandHandler.handlePgt(msg); }},
+    {"pex", [this](const std::string &msg) { _commandHandler.handlePex(msg); }}
   };
 
   try {


### PR DESCRIPTION
This pull request includes updates to the `Makefile` to switch the client build system to CMake, along with changes in the `GameEngine` class to introduce new network commands and replace `std::clamp` with a custom `Clamp` function. Below is a summary of the most important changes, grouped by theme.

### Build System Updates:
* Updated `Makefile` to rename the client directory from `client` to `gui` and added a dedicated build directory (`ZAPPY_CLIENT_BUILD_DIR`) for the client.
* Replaced the client's build process with CMake commands in the `Makefile`, including directory creation and cleanup steps. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L22-R33) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L38)

### Game Engine Enhancements:
* Replaced `std::clamp` with a custom `Clamp` function in `gui/src/gameEngine/GameEngine.cpp` to set the world scale.
* Added support for new network commands (`pic`, `pie`, `pfk`, `pdr`, `pgt`, `pex`) in the `processNetworkMessages` method of `GameEngine`.…at the root